### PR TITLE
feat/fix/test: 에러 핸들러 추가, api 작성/QueryDSL에러 해결/TimeStamptoString 테스트 추가

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/backend/src/main/java/com/HUFS19/backend/common/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/HUFS19/backend/common/dto/ErrorResponse.java
@@ -1,15 +1,16 @@
 package com.HUFS19.backend.common.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class ErrorResponse {
-//    private int status;
+    private HttpStatus status;
+    private int code;
     private String message;
 
-    public ErrorResponse(String message){
-        this.message=message;
-    }
 }

--- a/backend/src/main/java/com/HUFS19/backend/common/util/ResponseUtils.java
+++ b/backend/src/main/java/com/HUFS19/backend/common/util/ResponseUtils.java
@@ -2,6 +2,8 @@ package com.HUFS19.backend.common.util;
 
 import com.HUFS19.backend.common.dto.ApiResponseDto;
 import com.HUFS19.backend.common.dto.ErrorResponse;
+import com.HUFS19.backend.error.ErrorCode;
+import org.springframework.http.HttpStatus;
 
 public class ResponseUtils {
     public static <T> ApiResponseDto<T> ok(T response){
@@ -11,10 +13,10 @@ public class ResponseUtils {
         return apiResponseDto;
     }
 
-    public static <T> ApiResponseDto<T> error(ErrorResponse response){
+    public static <T> ApiResponseDto<T> error(HttpStatus status, int code,  String message){
         ApiResponseDto apiResponseDto = new ApiResponseDto();
         apiResponseDto.setSuccess(false);
-        apiResponseDto.setError(response);
+        apiResponseDto.setError(new ErrorResponse(status, code, message));
         return apiResponseDto;
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
@@ -2,7 +2,9 @@ package com.HUFS19.backend.controller;
 
 import com.HUFS19.backend.common.dto.ApiResponseDto;
 import com.HUFS19.backend.common.util.ResponseUtils;
+import com.HUFS19.backend.dto.chatRoom.ChatRoomDetail;
 import com.HUFS19.backend.service.ChatRoomService;
+import com.HUFS19.backend.service.MessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,22 +13,28 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.List;
 
 @Controller
 @RequestMapping("/chatRoomApi")
 public class ChatRoomController {
 
     ChatRoomService chatRoomService;
+    MessageService messageService;
 
     @Autowired
-    public ChatRoomController(ChatRoomService chatRoomService){
+    public ChatRoomController(ChatRoomService chatRoomService, MessageService messageService){
         this.chatRoomService=chatRoomService;
+        this.messageService=messageService;
     }
 
     @GetMapping("/{userId}/chatRoomLIst")
     @ResponseBody
     public ApiResponseDto getChatRoomList(@PathVariable("userId") String userId){
-       return ResponseUtils.ok(chatRoomService.getChatRoomList(userId));
+        List<ChatRoomDetail> chatRoomList=chatRoomService.getChatRoomList(userId);
+        chatRoomList.forEach(r->r.setLastMessageDto(messageService.getLastMessage(r.getId())));
+
+        return ResponseUtils.ok(chatRoomList);
     }
 
     @GetMapping("/{productId}/chat/{inquirerId}")

--- a/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
@@ -1,0 +1,30 @@
+package com.HUFS19.backend.controller;
+
+import com.HUFS19.backend.common.dto.ApiResponseDto;
+import com.HUFS19.backend.common.util.ResponseUtils;
+import com.HUFS19.backend.service.ChatRoomService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/chatRoomApi")
+public class ChatRoomController {
+
+    ChatRoomService chatRoomService;
+
+    @Autowired
+    public ChatRoomController(ChatRoomService chatRoomService){
+        this.chatRoomService=chatRoomService;
+    }
+
+    @GetMapping("/{userId}/chatRoomLIst")
+    @ResponseBody
+    public ApiResponseDto getChatroomList(@PathVariable("userId") String userId){
+       return ResponseUtils.ok(chatRoomService.getChatRoomList(userId));
+    }
+
+}

--- a/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/ChatRoomController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.security.spec.AlgorithmParameterSpec;
+
 @Controller
 @RequestMapping("/chatRoomApi")
 public class ChatRoomController {
@@ -23,8 +25,15 @@ public class ChatRoomController {
 
     @GetMapping("/{userId}/chatRoomLIst")
     @ResponseBody
-    public ApiResponseDto getChatroomList(@PathVariable("userId") String userId){
+    public ApiResponseDto getChatRoomList(@PathVariable("userId") String userId){
        return ResponseUtils.ok(chatRoomService.getChatRoomList(userId));
     }
+
+    @GetMapping("/{productId}/chat/{inquirerId}")
+    @ResponseBody
+    public ApiResponseDto getChatRoom(@PathVariable("productId") int productId, @PathVariable("inquirerId") String inquirerId){
+        return ResponseUtils.ok((chatRoomService.getChatRoom(productId, inquirerId)));
+    }
+
 
 }

--- a/backend/src/main/java/com/HUFS19/backend/controller/MessageController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/MessageController.java
@@ -1,0 +1,33 @@
+package com.HUFS19.backend.controller;
+
+import com.HUFS19.backend.common.dto.ApiResponseDto;
+import com.HUFS19.backend.common.util.ResponseUtils;
+import com.HUFS19.backend.service.MessageService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/messageAPI")
+public class MessageController {
+    MessageService messageService;
+
+
+    public MessageController(MessageService messageService){
+        this.messageService = messageService;
+    }
+
+    @GetMapping("/chatroom/{chatroomId}/lastMessage")
+    @ResponseBody
+    public ApiResponseDto getLastMessage(@PathVariable("chatroomId")int chatroomId){
+        return ResponseUtils.ok(messageService.getLastMessage(chatroomId));
+    }
+
+    @GetMapping("/messageAPI/chatroom/{chatroomId}")
+    @ResponseBody
+    public ApiResponseDto getRecentMessage(@PathVariable("chatroomId")int chatroomId){
+        return ResponseUtils.ok(messageService.getAllMessage(chatroomId));
+    }
+}

--- a/backend/src/main/java/com/HUFS19/backend/controller/ProductImgController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/ProductImgController.java
@@ -30,7 +30,7 @@ public class ProductImgController {
     public ApiResponseDto getProductimgs(@PathVariable("productId")int productId){
         List<ProductImgDto> imgs = productImgService.getImg(productId);
         if(imgs.isEmpty()){
-            return ResponseUtils.error(new ErrorResponse("상품 이미지를 찾을 수 없습니다."));
+            throw new IllegalArgumentException();
         }
         return ResponseUtils.ok(imgs);
 

--- a/backend/src/main/java/com/HUFS19/backend/controller/UserController.java
+++ b/backend/src/main/java/com/HUFS19/backend/controller/UserController.java
@@ -4,6 +4,8 @@ import com.HUFS19.backend.common.dto.ApiResponseDto;
 import com.HUFS19.backend.common.dto.ErrorResponse;
 import com.HUFS19.backend.common.dto.SuccessResponse;
 import com.HUFS19.backend.common.util.ResponseUtils;
+import com.HUFS19.backend.error.CustumException;
+import com.HUFS19.backend.error.ErrorCode;
 import com.HUFS19.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -26,7 +28,7 @@ public class UserController {
     ApiResponseDto checkIdDuplication(@PathVariable("id") String id){
         boolean isDuplicated = userService.checkIdDuplication(id);
         if(isDuplicated){
-            return ResponseUtils.error(new ErrorResponse("이미 존재하는 아이디입니다."));
+           throw new CustumException(ErrorCode.USER_ID_CONFLICT);
         }
         return ResponseUtils.ok(new SuccessResponse("사용가능한 아이디입니다."));
     }

--- a/backend/src/main/java/com/HUFS19/backend/dto/chatRoom/ChatRoomDetail.java
+++ b/backend/src/main/java/com/HUFS19/backend/dto/chatRoom/ChatRoomDetail.java
@@ -1,6 +1,6 @@
 package com.HUFS19.backend.dto.chatRoom;
 
-import com.HUFS19.backend.repository.user.User;
+import com.HUFS19.backend.dto.message.LastMessageDto;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +10,7 @@ public class ChatRoomDetail {
     private int id;
     private String userId;
     private String inquirerId;
-    private int categoryId;
     private int productId;
+    private String productName;
+    private LastMessageDto lastMessageDto;
 }

--- a/backend/src/main/java/com/HUFS19/backend/dto/chatRoom/ChatRoomDetail.java
+++ b/backend/src/main/java/com/HUFS19/backend/dto/chatRoom/ChatRoomDetail.java
@@ -1,0 +1,15 @@
+package com.HUFS19.backend.dto.chatRoom;
+
+import com.HUFS19.backend.repository.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRoomDetail {
+    private int id;
+    private String userId;
+    private String inquirerId;
+    private int categoryId;
+    private int productId;
+}

--- a/backend/src/main/java/com/HUFS19/backend/dto/message/LastMessageDto.java
+++ b/backend/src/main/java/com/HUFS19/backend/dto/message/LastMessageDto.java
@@ -1,0 +1,13 @@
+package com.HUFS19.backend.dto.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LastMessageDto {
+    String date;
+    String content;
+}

--- a/backend/src/main/java/com/HUFS19/backend/error/CustumException.java
+++ b/backend/src/main/java/com/HUFS19/backend/error/CustumException.java
@@ -1,0 +1,10 @@
+package com.HUFS19.backend.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustumException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/backend/src/main/java/com/HUFS19/backend/error/ErrorCode.java
+++ b/backend/src/main/java/com/HUFS19/backend/error/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.HUFS19.backend.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INTER_SERVER_EROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 장애가 발생했습니다."),
+    USER_ID_CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.value(), "이미 존재하는 아이디입니다.");
+
+    private HttpStatus status;
+    private int code;
+    private String message;
+}

--- a/backend/src/main/java/com/HUFS19/backend/error/ErrorHandler.java
+++ b/backend/src/main/java/com/HUFS19/backend/error/ErrorHandler.java
@@ -1,0 +1,28 @@
+package com.HUFS19.backend.error;
+
+import com.HUFS19.backend.common.dto.ApiResponseDto;
+import com.HUFS19.backend.common.util.ResponseUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ErrorHandler {
+
+    @ExceptionHandler
+    public ApiResponseDto handleUserConflict(CustumException e){
+        log.warn("handleUserConflict", e);
+        return makeResponse(e.getErrorCode());
+
+    }
+    @ExceptionHandler
+    public ApiResponseDto handleAllException(Exception e){
+        log.warn("handleAllException", e);
+        return makeResponse(ErrorCode.INTER_SERVER_EROR);
+    }
+
+    private ApiResponseDto makeResponse(ErrorCode errorCode){
+        return ResponseUtils.error(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/com/HUFS19/backend/repository/category/Category.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/category/Category.java
@@ -1,9 +1,6 @@
 package com.HUFS19.backend.repository.category;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,10 +12,14 @@ import lombok.Setter;
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int categoryId;
-    private String categoryName;
 
-    public Category (String categoryName){
-        this.categoryName=categoryName;
+    @Column(name="category_id")
+    private int id;
+
+    @Column(name="category_name")
+    private String name;
+
+    public Category (String name){
+        this.name =name;
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/category/CategoryRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/category/CategoryRepositoryImp.java
@@ -17,7 +17,7 @@ public class CategoryRepositoryImp implements CategoryRepository {
     @Override
     public int save(Category category) {
         em.persist(category);
-        return category.getCategoryId();
+        return category.getId();
     }
 
     @Override
@@ -34,7 +34,7 @@ public class CategoryRepositoryImp implements CategoryRepository {
 
     @Override
     public Optional<Category> findByName(String categoryName) {
-        List<Category> result = em.createQuery("select c from Category c where c.categoryName = :categoryName", Category.class)
+        List<Category> result = em.createQuery("select c from Category c where c.name = :categoryName", Category.class)
                 .setParameter("categoryName", categoryName)
                 .getResultList();
 

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoom.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoom.java
@@ -16,18 +16,18 @@ public class ChatRoom {
     @Column(name = "chat_room_id")
     private int id;
     @ManyToOne
-    @JoinColumn(name="productId")
+    @JoinColumn(name="product_id")
     private Product product;
 
     @ManyToOne
-    @JoinColumn(name="userId")
+    @JoinColumn(name="user_id")
     private User user;
 
     @ManyToOne
-    @JoinColumn(name="categoryId")
+    @JoinColumn(name="category_id")
     private Category category;
 
     @ManyToOne
-    @JoinColumn(name="inquirerId")
+    @JoinColumn(name="inquirerd")
     private User inquirer;
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoom.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoom.java
@@ -28,6 +28,6 @@ public class ChatRoom {
     private Category category;
 
     @ManyToOne
-    @JoinColumn(name="inquirerd")
+    @JoinColumn(name="inquirer_id")
     private User inquirer;
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
@@ -1,7 +1,9 @@
 package com.HUFS19.backend.repository.chatRoom;
 
+import com.HUFS19.backend.dto.chatRoom.ChatRoomDetail;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -9,5 +11,5 @@ public interface ChatRoomRepository {
     int save(ChatRoom chatRoom);
     Optional<ChatRoom> findById(int id);
     Optional<ChatRoom> findByProductId(int productId);
-
+    List<ChatRoom> findChatRoomByUserId(String userId);
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
@@ -11,5 +11,6 @@ public interface ChatRoomRepository {
     int save(ChatRoom chatRoom);
     Optional<ChatRoom> findById(int id);
     Optional<ChatRoom> findByProductId(int productId);
-    List<ChatRoom> findChatRoomByUserId(String userId);
+    List<ChatRoom> findByUserId(String userId);
+    Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId);
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepository.java
@@ -11,6 +11,6 @@ public interface ChatRoomRepository {
     int save(ChatRoom chatRoom);
     Optional<ChatRoom> findById(int id);
     Optional<ChatRoom> findByProductId(int productId);
-    List<ChatRoom> findByUserId(String userId);
+    List<ChatRoomDetail> findByUserId(String userId);
     Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId);
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
@@ -1,15 +1,26 @@
 package com.HUFS19.backend.repository.chatRoom;
 
+import com.HUFS19.backend.dto.chatRoom.ChatRoomDetail;
+import com.HUFS19.backend.dto.product.ProductImgDto;
+import com.HUFS19.backend.repository.productImg.QProductImg;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.expression.spel.ast.Projection;
 
 import java.util.List;
 import java.util.Optional;
 
+//findChatRoomByUserId() DTO 컬럼만 추출하면 userId, inquirerId null로 뜨는 문제
+
 public class ChatRoomRepositoryImp implements ChatRoomRepository{
-    private EntityManager em;
+    private final EntityManager em;
+    private final JPAQueryFactory query;
 
     public ChatRoomRepositoryImp(EntityManager em){
         this.em=em;
+        query = new JPAQueryFactory(em);
     }
 
     @Override
@@ -29,5 +40,28 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
                 .setParameter("productId", productId)
                 .getResultList();
         return result.stream().findAny();
+    }
+
+    @Override
+    public List<ChatRoom> findChatRoomByUserId(String userId) {
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+
+        return query.selectFrom(chatRoom).where((chatRoom.user.id.eq(userId))
+                        .or(chatRoom.inquirer.id.eq(userId)))
+                .fetch();
+//
+//        List<ChatRoomDetail>chatRoomDtos=query
+//                .select(Projections.bean(
+//                        ChatRoomDetail.class,
+//                        chatRoom.id,
+//                        chatRoom.user.id,
+//                        chatRoom.inquirer.id,
+//                        chatRoom.category.categoryId,
+//                        chatRoom.product.id))
+//                .from(chatRoom)
+//                .where((chatRoom.user.id.eq(userId))
+//                        .or(chatRoom.inquirer.id.eq(userId)))
+//                .fetch();
+//        return chatRoomDtos;
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 public class ChatRoomRepositoryImp implements ChatRoomRepository{
     private final EntityManager em;
     private final JPAQueryFactory query;
+    private QChatRoom chatRoom = QChatRoom.chatRoom;
+
 
     public ChatRoomRepositoryImp(EntityManager em){
         this.em=em;
@@ -43,9 +45,7 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
     }
 
     @Override
-    public List<ChatRoom> findChatRoomByUserId(String userId) {
-        QChatRoom chatRoom = QChatRoom.chatRoom;
-
+    public List<ChatRoom> findByUserId(String userId) {
         return query.selectFrom(chatRoom).where((chatRoom.user.id.eq(userId))
                         .or(chatRoom.inquirer.id.eq(userId)))
                 .fetch();
@@ -63,5 +63,18 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
 //                        .or(chatRoom.inquirer.id.eq(userId)))
 //                .fetch();
 //        return chatRoomDtos;
+    }
+
+    @Override
+    public Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId) {
+        return Optional.ofNullable(
+                query.select(Projections.bean(ChatRoomDetail.class,
+                chatRoom.id,
+                chatRoom.user.id,
+                chatRoom.inquirer.id,
+                chatRoom.category.categoryId,
+                chatRoom.product.id
+                )).from(chatRoom).where((chatRoom.product.id.eq(productId)).and(chatRoom.inquirer.id.eq(inquirerId))).fetchOne()
+                    );
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
@@ -17,8 +17,6 @@ import java.util.Optional;
 public class ChatRoomRepositoryImp implements ChatRoomRepository{
     private final EntityManager em;
     private final JPAQueryFactory query;
-    private QChatRoom chatRoom = QChatRoom.chatRoom;
-
 
     public ChatRoomRepositoryImp(EntityManager em){
         this.em=em;
@@ -46,10 +44,12 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
 
     @Override
     public List<ChatRoom> findByUserId(String userId) {
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+
         return query.selectFrom(chatRoom).where((chatRoom.user.id.eq(userId))
                         .or(chatRoom.inquirer.id.eq(userId)))
                 .fetch();
-//
+
 //        List<ChatRoomDetail>chatRoomDtos=query
 //                .select(Projections.bean(
 //                        ChatRoomDetail.class,
@@ -67,14 +67,24 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
 
     @Override
     public Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId) {
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+
         return Optional.ofNullable(
                 query.select(Projections.bean(ChatRoomDetail.class,
-                chatRoom.id,
-                chatRoom.user.id,
-                chatRoom.inquirer.id,
-                chatRoom.category.categoryId,
-                chatRoom.product.id
-                )).from(chatRoom).where((chatRoom.product.id.eq(productId)).and(chatRoom.inquirer.id.eq(inquirerId))).fetchOne()
-                    );
+                        chatRoom.id,
+                        chatRoom.user.id.as("userId"),
+                        chatRoom.inquirer.id.as("inquirerId"),
+                        chatRoom.category.id.as("categoryId"),
+                        chatRoom.product.id.as("productId")
+                )).from(chatRoom).where(chatRoom.id.eq(1)).fetchOne());
+//        return Optional.ofNullable(
+//                query.select(Projections.bean(ChatRoomDetail.class,
+//                chatRoom.id,
+//                chatRoom.user.id,
+//                chatRoom.inquirer.id,
+//                chatRoom.category.categoryId,
+//                chatRoom.product.id
+//                )).from(chatRoom).where((chatRoom.product.id.eq(productId)).and(chatRoom.inquirer.id.eq(inquirerId))).fetchOne()
+//                    );
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
@@ -12,11 +12,11 @@ import org.springframework.expression.spel.ast.Projection;
 import java.util.List;
 import java.util.Optional;
 
-//findChatRoomByUserId() DTO 컬럼만 추출하면 userId, inquirerId null로 뜨는 문제
-
 public class ChatRoomRepositoryImp implements ChatRoomRepository{
     private final EntityManager em;
     private final JPAQueryFactory query;
+
+    private QChatRoom chatRoom = QChatRoom.chatRoom;
 
     public ChatRoomRepositoryImp(EntityManager em){
         this.em=em;
@@ -43,48 +43,42 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
     }
 
     @Override
-    public List<ChatRoom> findByUserId(String userId) {
-        QChatRoom chatRoom = QChatRoom.chatRoom;
+    public List<ChatRoomDetail> findByUserId(String userId) {
 
-        return query.selectFrom(chatRoom).where((chatRoom.user.id.eq(userId))
-                        .or(chatRoom.inquirer.id.eq(userId)))
-                .fetch();
-
-//        List<ChatRoomDetail>chatRoomDtos=query
-//                .select(Projections.bean(
-//                        ChatRoomDetail.class,
-//                        chatRoom.id,
-//                        chatRoom.user.id,
-//                        chatRoom.inquirer.id,
-//                        chatRoom.category.categoryId,
-//                        chatRoom.product.id))
-//                .from(chatRoom)
-//                .where((chatRoom.user.id.eq(userId))
-//                        .or(chatRoom.inquirer.id.eq(userId)))
-//                .fetch();
-//        return chatRoomDtos;
-    }
-
-    @Override
-    public Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId) {
-        QChatRoom chatRoom = QChatRoom.chatRoom;
-
-        return Optional.ofNullable(
-                query.select(Projections.bean(ChatRoomDetail.class,
+        return query.select(
+                Projections.bean(
+                        ChatRoomDetail.class,
                         chatRoom.id,
                         chatRoom.user.id.as("userId"),
                         chatRoom.inquirer.id.as("inquirerId"),
                         chatRoom.category.id.as("categoryId"),
                         chatRoom.product.id.as("productId")
-                )).from(chatRoom).where(chatRoom.id.eq(1)).fetchOne());
-//        return Optional.ofNullable(
-//                query.select(Projections.bean(ChatRoomDetail.class,
-//                chatRoom.id,
-//                chatRoom.user.id,
-//                chatRoom.inquirer.id,
-//                chatRoom.category.categoryId,
-//                chatRoom.product.id
-//                )).from(chatRoom).where((chatRoom.product.id.eq(productId)).and(chatRoom.inquirer.id.eq(inquirerId))).fetchOne()
-//                    );
+                ))
+                .from(chatRoom)
+                .where(
+                        (chatRoom.user.id.eq(userId))
+                        .or(chatRoom.inquirer.id.eq(userId)))
+                .fetch();
+    }
+
+    @Override
+    public Optional<ChatRoomDetail> findByProductInquirer(int productId, String inquirerId) {
+
+        return Optional.ofNullable(
+                query.select(
+                        Projections.bean(
+                                ChatRoomDetail.class,
+                                chatRoom.id,
+                                chatRoom.user.id.as("userId"),
+                                chatRoom.inquirer.id.as("inquirerId"),
+                                chatRoom.category.id.as("categoryId"),
+                                chatRoom.product.id.as("productId")
+                        ))
+                        .from(chatRoom)
+                        .where(
+                                (chatRoom.product.id.eq(productId))
+                                .and(chatRoom.inquirer.id.eq(inquirerId))
+                        ).fetchOne());
+
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/chatRoom/ChatRoomRepositoryImp.java
@@ -51,8 +51,9 @@ public class ChatRoomRepositoryImp implements ChatRoomRepository{
                         chatRoom.id,
                         chatRoom.user.id.as("userId"),
                         chatRoom.inquirer.id.as("inquirerId"),
-                        chatRoom.category.id.as("categoryId"),
-                        chatRoom.product.id.as("productId")
+                        chatRoom.product.id.as("productId"),
+                        chatRoom.product.name.as("productName")
+
                 ))
                 .from(chatRoom)
                 .where(

--- a/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepository.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepository.java
@@ -2,9 +2,14 @@ package com.HUFS19.backend.repository.message;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository public interface MessageRepository {
     int save(Message message);
     Optional<Message> findById(int id);
+
+    List<Message> findAllByChatRoom(int chatRoomId);
+
+    Optional<Message> findLastByChatRoom(int chatRoomId);
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepository.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepository.java
@@ -1,5 +1,6 @@
 package com.HUFS19.backend.repository.message;
 
+import com.HUFS19.backend.dto.message.LastMessageDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepositoryImp.java
@@ -1,14 +1,19 @@
 package com.HUFS19.backend.repository.message;
 
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
+import java.util.List;
 import java.util.Optional;
 
 public class MessageRepositoryImp implements MessageRepository{
-    private EntityManager em;
-
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+    private QMessage message = QMessage.message;
     public MessageRepositoryImp(EntityManager em){
         this.em=em;
+        this.query=new JPAQueryFactory(em);
     }
 
     @Override
@@ -16,9 +21,22 @@ public class MessageRepositoryImp implements MessageRepository{
         em.persist(message);
         return message.getId();
     }
-
     @Override
     public Optional<Message> findById(int id) {
         return Optional.ofNullable(em.find(Message.class, id));
+    }
+
+    @Override
+    public List<Message> findAllByChatRoom(int chatRoomId) {
+        return query.selectFrom(message).where(message.chatRoom.id.eq(chatRoomId)).fetch();
+    }
+
+    @Override
+    public Optional<Message> findLastByChatRoom(int chatRoomId) {
+        return Optional.ofNullable(
+                query.selectFrom(message).
+                        where(message.chatRoom.id.eq(chatRoomId)).
+                        orderBy(message.time.desc()).
+                        fetchFirst());
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/message/MessageRepositoryImp.java
@@ -1,5 +1,7 @@
 package com.HUFS19.backend.repository.message;
 
+import com.HUFS19.backend.dto.message.LastMessageDto;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 public class ProductImgRepositoryImp implements ProductImgRepository{
     private EntityManager em;
     private JPAQueryFactory query;
+    private QProductImg productImg = QProductImg.productImg;
+
     public ProductImgRepositoryImp(EntityManager em){
         this.em=em;
         query = new JPAQueryFactory(em);
@@ -32,17 +34,18 @@ public class ProductImgRepositoryImp implements ProductImgRepository{
 
     @Override
     public List<ProductImgDto> findByProductId(int productId) {
-        QProductImg productImg = QProductImg.productImg;
-        List<ProductImgDto> imgDtos = query.select(Projections.bean(
-                ProductImgDto.class,
-                productImg.id,
-                productImg.product.id.as("productId"),
-                productImg.order,
-                productImg.img))
-                .from(productImg)
-                .where(productImg.product.id.eq(productId)).
-                fetch();
 
-        return imgDtos;
+        return query.select(
+                Projections.bean(
+                        ProductImgDto.class,
+                        productImg.id,
+                        productImg.product.id.as("productId"),
+                        productImg.order,
+                        productImg.img
+                ))
+                .from(productImg)
+                .where(productImg.product.id.eq(productId))
+                .fetch();
+
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
@@ -44,9 +44,5 @@ public class ProductImgRepositoryImp implements ProductImgRepository{
                 fetch();
 
         return imgDtos;
-//        List<ProductImg> result = em.createQuery("select pimg from ProductImg pimg where pimg.product.id=:productId", ProductImg.class)
-//                .setParameter("productId", productId)
-//                .getResultList();
-//        return result.stream().findAny();
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
+++ b/backend/src/main/java/com/HUFS19/backend/repository/productImg/ProductImgRepositoryImp.java
@@ -36,7 +36,7 @@ public class ProductImgRepositoryImp implements ProductImgRepository{
         List<ProductImgDto> imgDtos = query.select(Projections.bean(
                 ProductImgDto.class,
                 productImg.id,
-                productImg.product.id,
+                productImg.product.id.as("productId"),
                 productImg.order,
                 productImg.img))
                 .from(productImg)

--- a/backend/src/main/java/com/HUFS19/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/CategoryService.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -21,7 +20,7 @@ public class CategoryService {
 
     public String getName(int id){
         Category category = categoryRepository.findById(id).orElseThrow(()-> new IllegalArgumentException("값이 없습니다."));
-        return category.getCategoryName();
+        return category.getName();
     }
 
     public List<Category> getAll(){

--- a/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
@@ -19,7 +19,7 @@ public class ChatRoomService {
         this.chatRoomRepository=chatRoomRepository;
     }
 
-    public List<ChatRoom> getChatRoomList(String userId){
+    public List<ChatRoomDetail> getChatRoomList(String userId){
         return chatRoomRepository.findByUserId(userId);
     }
 

--- a/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
@@ -1,0 +1,24 @@
+package com.HUFS19.backend.service;
+
+import com.HUFS19.backend.dto.chatRoom.ChatRoomDetail;
+import com.HUFS19.backend.repository.chatRoom.ChatRoom;
+import com.HUFS19.backend.repository.chatRoom.ChatRoomRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ChatRoomService {
+    ChatRoomRepository chatRoomRepository;
+    @Autowired
+    public ChatRoomService(ChatRoomRepository chatRoomRepository){
+        this.chatRoomRepository=chatRoomRepository;
+    }
+
+    public List<ChatRoom> getChatRoomList(String userId){
+        return chatRoomRepository.findChatRoomByUserId(userId);
+    }
+}

--- a/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.HUFS19.backend.service;
 
 import com.HUFS19.backend.dto.chatRoom.ChatRoomDetail;
+import com.HUFS19.backend.repository.category.Category;
 import com.HUFS19.backend.repository.chatRoom.ChatRoom;
 import com.HUFS19.backend.repository.chatRoom.ChatRoomRepository;
 import jakarta.transaction.Transactional;
@@ -19,6 +20,11 @@ public class ChatRoomService {
     }
 
     public List<ChatRoom> getChatRoomList(String userId){
-        return chatRoomRepository.findChatRoomByUserId(userId);
+        return chatRoomRepository.findByUserId(userId);
+    }
+
+    public ChatRoomDetail getChatRoom(int productId, String inquirerId) {
+        ChatRoomDetail chatRoomDetail = chatRoomRepository.findByProductInquirer(productId, inquirerId).orElseThrow(()->new IllegalArgumentException("채팅방이 없습니다."));
+        return chatRoomDetail;
     }
 }

--- a/backend/src/main/java/com/HUFS19/backend/service/MessageService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/MessageService.java
@@ -1,0 +1,27 @@
+package com.HUFS19.backend.service;
+
+import com.HUFS19.backend.repository.message.Message;
+import com.HUFS19.backend.repository.message.MessageRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class MessageService {
+    MessageRepository messageRepository;
+
+    public MessageService(MessageRepository messageRepository){
+        this.messageRepository = messageRepository;
+    }
+
+    public List<Message> getAllMessage(int ChatRoomId){
+        return messageRepository.findAllByChatRoom(ChatRoomId);
+    };
+
+    public Message getLastMessage(int ChatRoomId) {
+        return messageRepository.findLastByChatRoom(ChatRoomId).get();
+    }
+}

--- a/backend/src/main/java/com/HUFS19/backend/service/MessageService.java
+++ b/backend/src/main/java/com/HUFS19/backend/service/MessageService.java
@@ -1,12 +1,15 @@
 package com.HUFS19.backend.service;
 
+import com.HUFS19.backend.dto.message.LastMessageDto;
 import com.HUFS19.backend.repository.message.Message;
 import com.HUFS19.backend.repository.message.MessageRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -21,7 +24,33 @@ public class MessageService {
         return messageRepository.findAllByChatRoom(ChatRoomId);
     };
 
-    public Message getLastMessage(int ChatRoomId) {
-        return messageRepository.findLastByChatRoom(ChatRoomId).get();
+    public LastMessageDto getLastMessage(int ChatRoomId) {
+         Optional<Message> lastMessage = messageRepository.findLastByChatRoom(ChatRoomId);
+
+        return lastMessage.map(message -> new LastMessageDto(timeStampToString(message.getTime()), message.getContent()))
+                .orElseGet(() -> new LastMessageDto("", "최근 메세지를 확인할 수 없습니다."));
+
+//        if (lastMessage.isPresent()){
+//            return new LastMessageDto(timeStampToString(lastMessage.get().getTime()), lastMessage.get().getContent());
+//        }
+//        else{
+//            return new LastMessageDto("", "최근 메세지를 확인할 수 없습니다.");
+//        }
+    }
+
+    public String timeStampToString(Timestamp timestamp){
+        String timeString = new SimpleDateFormat("yyyy/MM/dd").format(timestamp);
+
+        String[] timeArray = timeString.split("/");
+        List<String> timeList= new ArrayList<>(Arrays.asList(timeArray));
+
+        timeList.replaceAll(s->Integer.toString(Integer.parseInt(s)));
+        timeList.add(1, "년 ");
+        timeList.add(3, "월 ");
+        timeList.add( "일");
+
+        String resultString = String.join("", timeList);
+
+        return resultString;
     }
 }

--- a/backend/src/main/resources/DBschema.sql
+++ b/backend/src/main/resources/DBschema.sql
@@ -308,5 +308,10 @@ INSERT INTO comment(user_id, product_id, content) values
                                                       ('lucky777', '1', '더쓸말도없다.... 위에 사람들 다 거짓말임 전 별로였어요');
 
 INSERT INTO chat_room(category_id, user_id, inquirer_id, product_id) values
-                                                      ('1', 'testID', 'user4444', '1')
+                                                      ('1', 'testID', 'user4444', '1');
+INSERT INTO message(chat_room_id, product_id, user_id, category_id, inquirer_id, sender_id, content) values
+                                                    ('1', '1', 'testID', '7', 'user4444', 'user4444', '안녕하세요!'),
+                                                    ('1', '1', 'testID', '7', 'user4444', 'testID', '네 안녕하세요!'),
+                                                    ('1', '1', 'testID', '7', 'user4444', 'user4444', '언제 구매하셨나요?'),
+                                                    ('1', '1', 'testID', '7', 'user4444', 'testID', '3개월 전입니다!');
 

--- a/backend/src/test/java/com/HUFS19/backend/repository/category/CategoryRepositoryImpTest.java
+++ b/backend/src/test/java/com/HUFS19/backend/repository/category/CategoryRepositoryImpTest.java
@@ -1,8 +1,5 @@
 package com.HUFS19.backend.repository.category;
 
-import com.HUFS19.backend.repository.category.Category;
-import com.HUFS19.backend.repository.category.CategoryRepository;
-import com.HUFS19.backend.repository.category.CategoryRepositoryImp;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -31,7 +28,7 @@ class CategoryRepositoryImpTest {
         int categoryId = categoryRepository.save(category);
         Category foundCategory = categoryRepository.findById(categoryId).get();
 
-        assertEquals(foundCategory.getCategoryName(), category.getCategoryName());
+        assertEquals(foundCategory.getName(), category.getName());
     }
 
 }

--- a/backend/src/test/java/com/HUFS19/backend/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/HUFS19/backend/service/MessageServiceTest.java
@@ -1,0 +1,44 @@
+package com.HUFS19.backend.service;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Scanner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MessageServiceTest {
+    @Autowired
+    MessageService messageService;
+
+    @Test
+    void timeStampToString() {
+        String sampleDateString = "2024/2/23 13:01:54";
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        try {
+            Date stringToDate = dateFormat.parse("2024/2/23 13:01:54");
+            Timestamp sampleTimestamp = new Timestamp(stringToDate.getTime());
+            System.out.println(sampleTimestamp);
+
+            assertEquals(sampleTimestamp instanceof Timestamp, true);
+
+            String resultString = messageService.timeStampToString(sampleTimestamp);
+
+            System.out.println(resultString);
+            assertEquals(resultString, "2024년 2월 23일");
+
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+
+    }
+}


### PR DESCRIPTION
## PR Type

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해주세요. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Configuration related changes
- [ ] Documentation content changes
- [x] Other... Please describe: test

## Related Issues
#38 
## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 에러 처리하는 RestControllerAdvice 클래스 추가
- [x] 채팅방 조회 api 추가
- [x] 마지막 메세지 조회 api 추가
- [x] 전체 메세지 조회 api 추가
- [x] QueryDSL dto 조회시 null 반환하는 에러 해결
- [x] 특정 유저의 채팅방 리스트  조회 api의 response 형식 변경
- [x] TimeStamp를 `yyyy년 mm월 dd일` 형식 String 으로 변경하는 메서드의 테스트 추가

## Other information
QueryDSL에러
원인: entity의 변수명과 dto의 멤버 변수명이 일치하지 않아 발생
해결: `as()` 매서드로 dto의 변수명 명시

불필요한 서버 통신을 줄이기 위해 `user-채팅방 리스트 조회 api` resonse 형식 변경  
[api 명세서](https://docs.google.com/spreadsheets/d/1o5oWC5IQP1jBZG_Xyrbm-Mfwm49D5sYScsgwrh4QtmU/edit#gid=687987276)

